### PR TITLE
change to local port

### DIFF
--- a/miner.erl
+++ b/miner.erl
@@ -1,7 +1,7 @@
 -module(miner)
 .
 -export([start/0, unpack_mining_data/1]).
-%-define(Peer, "http://localhost:8080/").%for a full node on same computer.
+%-define(Peer, "http://localhost:8081/").%for a full node on same computer.
 %-define(Peer, "http://localhost:8085/").%for a mining pool on the same computer.
 -define(Peer, "http://146.185.142.103:8085/").%for a mining pool on the server.
 -define(CORES, 3).


### PR DESCRIPTION
I get the following error on the full node when using the default port of 8080 for "full node on same computer":
```
I can't handle this ["mining_data"]
```

This is the error I get on the c-miner:
```
** exception error: no match of right hand side value <<"[\"error\"]">>
     in function  miner:unpack_mining_data/1 (miner.erl, line 20)
     in call from miner:start_c_miners/1 (miner.erl, line 39)
```

When I change it to 8081, the c-miner works as expected.